### PR TITLE
Use official knockout bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
         "jquery":"1.9.1",
         "requirejs":"2.1.11",
         "requirejs-text":"2.0.7",
-        "knockout.js":"3.1.0"
+        "knockout":"3.1.0"
     }
 }


### PR DESCRIPTION
See http://knockoutjs.com/downloads/index.html

They use the official `knockout` package instead of `knockout.js`

Additional benefit is that the `knockout` version includes package versions newer than 3.1.0, making future upgrades possible. The `knockout.js` hasn't been updated since 3.1.0.