### PR TITLE
Publish to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "durandal",
+  "version": "2.1.0",
+  "description": "Durandal is a cross-device, cross-platform client framework written in JavaScript and designed to make Single Page Applications (SPAs) easy to create and maintain. We've used it to build apps for PC, Mac, Linux, iOS and Android...and now it's your turn...",
+  "main": "js/app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BlueSpire/Durandal-Bower.git"
+  },
+  "keywords": [
+    "durandal",
+    "jquery",
+    "knockout",
+    "requirejs",
+    "spa"
+  ],
+  "author": "Blue Spire",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/BlueSpire/Durandal-Bower/issues"
+  },
+  "homepage": "https://github.com/BlueSpire/Durandal-Bower#readme",
+  "dependencies": {
+    "jquery": "^1.9.1",
+    "knockout": "^3.1.0",
+    "requirejs": "^2.1.11",
+    "requirejs-text": "^2.0.12"
+  }
+}


### PR DESCRIPTION
Added package.json for NPM publishing. Can you merge this and do an `npm publish`? It would be great for those of us using a Webpack or Browserify workflow!
